### PR TITLE
fix: role mentions missing role colour

### DIFF
--- a/index.js
+++ b/index.js
@@ -198,7 +198,9 @@ module.exports = class RoleColorEverywhere extends Plugin {
     })
 
     inject('rce-user-mentions-style', Mention, 'default', ([ props ], res) => {
-      res.props.style = props.style
+      if (props.style) {
+        res.props.style = props.style
+      }
       return res;
     })
 


### PR DESCRIPTION
Ironically, using this plugin, regardless if the option to show the role colour in Mentions is enabled or not, removes the default Discord behaviour where role mentions in messages inherit the colour of the role. The plugin currently makes all role mentions Blurple/the default colour.